### PR TITLE
fix to work on all conforming lisp implementations

### DIFF
--- a/utilities.lisp
+++ b/utilities.lisp
@@ -54,7 +54,7 @@ Partial state accepted as input, too, for parsing in chunks."
         (cond
           ((eql char #\newline)
            (if lf (unpeek-done) (setf lf t)))
-          ((eql char #\cr)
+          ((eql char #\Return)
            (if (or cr lf) (unpeek-done) (setf cr t)))
           ((eql char eof)
            (cond


### PR DESCRIPTION
CLHS Section 13.1.7 Character Names
https://www.lispworks.com/documentation/HyperSpec/Body/13_ag.htm
does not require #\cr to be available, just #\Return. In particular, this fixes inferior-shell to work on an old (conforming) version of clisp I sometimes still use.